### PR TITLE
Improve support for services and autocomplete details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to the "roblox-lua-autofills" extension will be documented i
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
-- Fixed inherited members not showing up for services
-- Fixed properties of services not showing up in autofill
-- Improved documentation provided in autofill, and added relevant Developer Reference links
+- Fixed inherited members not showing up for services.
+- Fixed properties of services not showing up in autofill.
+- Improved documentation provided in autofill, and added relevant Developer Reference links.
 
 ## [1.7.1]
 - Service auto-importer will now suggest for non-idiomatic whitespace in service declarations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the "roblox-lua-autofills" extension will be documented i
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+- Fixed inherited members not showing up for services
+- Fixed properties of services not showing up in autofill
+- Improved documentation provided in autofill, and added relevant Developer Reference links
+
 ## [1.7.1]
 - Service auto-importer will now suggest for non-idiomatic whitespace in service declarations.
 

--- a/src/dump.ts
+++ b/src/dump.ts
@@ -73,15 +73,17 @@ export type MemberTag =
     | "ReadOnly"
     | "Yields"
 
+export interface ApiPropertySecurity {
+    Read: SecurityType,
+    Write: SecurityType,
+}
+
 export interface ApiMemberBase {
     MemberType: string,
     Name: string,
     Security:
         | SecurityType
-        | {
-                Read: SecurityType,
-                Write: SecurityType,
-          },
+        | ApiPropertySecurity,
     Tags?: Array<MemberTag>,
     Description?: string,
 }

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -2,9 +2,9 @@ import * as vscode from "vscode"
 import { ApiEnum, getApiDump } from "./dump"
 
 export class EnumCompletionProvider implements vscode.CompletionItemProvider {
-    public enumItems: Promise<vscode.CompletionItem[]>
-    public enumNamesAndItems: Promise<{ [name: string]: vscode.CompletionItem[] }>
-    public enumProperties = [
+    enumItems: Promise<vscode.CompletionItem[]>
+    enumNamesAndItems: Promise<{ [name: string]: vscode.CompletionItem[] }>
+    enumProperties = [
         new vscode.CompletionItem("Name", vscode.CompletionItemKind.Field),
         new vscode.CompletionItem("Value", vscode.CompletionItemKind.Field),
     ]
@@ -33,7 +33,7 @@ export class EnumCompletionProvider implements vscode.CompletionItemProvider {
         })()
     }
 
-    public async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
+    async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
         const textSplit = document.lineAt(position.line).text.substr(0, position.character).split(/[^\w\.]+/)
         const text = textSplit[textSplit.length - 1]
 

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -1,9 +1,13 @@
 import * as vscode from "vscode"
-import { getApiDump, ApiEnum } from "./dump"
+import { ApiEnum, getApiDump } from "./dump"
 
 export class EnumCompletionProvider implements vscode.CompletionItemProvider {
-    enumItems: Promise<vscode.CompletionItem[]>
-    enumNamesAndItems: Promise<{ [name: string]: vscode.CompletionItem[] }>
+    public enumItems: Promise<vscode.CompletionItem[]>
+    public enumNamesAndItems: Promise<{ [name: string]: vscode.CompletionItem[] }>
+    public enumProperties = [
+        new vscode.CompletionItem("Name", vscode.CompletionItemKind.Field),
+        new vscode.CompletionItem("Value", vscode.CompletionItemKind.Field),
+    ]
 
     constructor() {
         this.enumItems = (async () => {
@@ -11,7 +15,8 @@ export class EnumCompletionProvider implements vscode.CompletionItemProvider {
 
             return apiDump.Enums
                 .map((eenum: ApiEnum) => new vscode.CompletionItem(
-                    eenum.Name
+                    eenum.Name,
+                    vscode.CompletionItemKind.Enum,
                 ))
         })()
 
@@ -20,14 +25,15 @@ export class EnumCompletionProvider implements vscode.CompletionItemProvider {
             const enumNamesAndItems: { [name: string]: vscode.CompletionItem[] } = {}
 
             for (const eenum of apiDump.Enums) {
-                enumNamesAndItems[eenum.Name] = eenum.Items.map((item) => new vscode.CompletionItem(item.Name))
+                enumNamesAndItems[eenum.Name] = eenum.Items.map(
+                    (item) => new vscode.CompletionItem(item.Name, vscode.CompletionItemKind.EnumMember))
             }
 
             return enumNamesAndItems
         })()
     }
 
-    async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
+    public async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
         const textSplit = document.lineAt(position.line).text.substr(0, position.character).split(/[^\w\.]+/)
         const text = textSplit[textSplit.length - 1]
 
@@ -41,6 +47,9 @@ export class EnumCompletionProvider implements vscode.CompletionItemProvider {
                 const enumName = tokens[1]
                 const items = (await this.enumNamesAndItems)[enumName]
                 return items || []
+            } else if (tokens.length === 4) {
+                // Enum.Name.EnumMember.NowImTypingThis
+                return this.enumProperties
             }
         }
     }

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,7 +1,7 @@
 // Service member auto complete
 
 import * as vscode from "vscode"
-import { ApiClass, getApiDump } from "./dump"
+import { ApiClass, ApiPropertySecurity, getApiDump } from "./dump"
 
 const UNSCRIPTABLE_TAGS: Set<string> = new Set([
     "Deprecated",
@@ -53,7 +53,12 @@ export class ServiceCompletionProvider implements vscode.CompletionItemProvider 
         let completionItems: vscode.CompletionItem[] = []
 
         for (const member of service.Members) {
-            if (member.Security !== "None") {
+            if (member.MemberType === "Property") {
+                const security = member.Security as ApiPropertySecurity
+                if (security.Read !== "None" && security.Write !== "None") {
+                    continue
+                }
+            } else if (member.Security !== "None") {
                 continue
             }
 

--- a/src/services.ts
+++ b/src/services.ts
@@ -14,6 +14,7 @@ const IMPORT_PATTERN = /^local \w+ = game:GetService\("\w+"\)\s*$/
 
 export class ServiceCompletionProvider implements vscode.CompletionItemProvider {
     public serviceMembers: Promise<Map<string, ApiClass>>
+    public servicesCompletion: Promise<vscode.CompletionItem[]>
 
     constructor() {
         this.serviceMembers = getApiDump().then((dump) => {
@@ -39,6 +40,19 @@ export class ServiceCompletionProvider implements vscode.CompletionItemProvider 
                     Tags: klass.Tags,
                 }
                 output.set(klass.Name, klassData)
+            }
+
+            return output
+        })
+
+        this.servicesCompletion = getApiDump().then((dump) => {
+            const output: vscode.CompletionItem[] = []
+
+            for (const klass of dump.Classes) {
+                if (klass.Tags !== undefined && klass.Tags.includes("Service")) {
+                    const completionItem = new vscode.CompletionItem(klass.Name, vscode.CompletionItemKind.Class)
+                    output.push(completionItem)
+                }
             }
 
             return output
@@ -180,6 +194,8 @@ export class ServiceCompletionProvider implements vscode.CompletionItemProvider 
                 const completionItems = await this.createCompletionItems(service, operator, true)
 
                 return completionItems
+            } else {
+                return this.servicesCompletion
             }
         }
 

--- a/src/services.ts
+++ b/src/services.ts
@@ -95,7 +95,7 @@ export class ServiceCompletionProvider implements vscode.CompletionItemProvider 
 
                     completionItem.detail = `(function) ${service.Name}:${member.Name}(${params.join(", ")}): ${member.ReturnType ? member.ReturnType.Name : "unknown"}`
                     completionItem.documentation = new vscode.MarkdownString(`[Developer Reference](https://developer.roblox.com/en-us/api-reference/function/${service.Name}/${member.Name})`)
-                    completionItem.insertText = new vscode.SnippetString(`${member.Name}($0)`)
+                    completionItem.insertText = new vscode.SnippetString(`${member.Name}(${params.length > 0 ? "$0)" : ")$0"}`)
 
                     completionItems.push(completionItem)
                 }

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,7 +1,7 @@
 // Service member auto complete
 
 import * as vscode from "vscode"
-import { ApiMember, getApiDump } from "./dump"
+import { ApiClass, getApiDump } from "./dump"
 
 const UNSCRIPTABLE_TAGS: Set<string> = new Set([
     "Deprecated",
@@ -13,15 +13,16 @@ const UNSCRIPTABLE_TAGS: Set<string> = new Set([
 const IMPORT_PATTERN = /^local \w+ = game:GetService\("\w+"\)\s*$/
 
 export class ServiceCompletionProvider implements vscode.CompletionItemProvider {
-    serviceMembers: Promise<Map<string, Array<ApiMember>>>
+    public serviceMembers: Promise<Map<string, ApiClass>>
 
     constructor() {
-        this.serviceMembers = getApiDump().then(dump => {
+        this.serviceMembers = getApiDump().then((dump) => {
             const output = new Map()
 
             for (const klass of dump.Classes) {
-                if (klass.Tags !== undefined && klass.Tags.includes("Service")) {
-                    output.set(klass.Name, klass.Members.filter((member) => {
+                const klassData = {
+                    Description: klass.Description,
+                    Members: klass.Members.filter((member) => {
                         const tags = member.Tags
                         if (tags !== undefined) {
                             for (const tag of tags) {
@@ -30,33 +31,112 @@ export class ServiceCompletionProvider implements vscode.CompletionItemProvider 
                                 }
                             }
                         }
-
                         return true
-                    }))
+                    }),
+                    MemoryCategory: klass.MemoryCategory,
+                    Name: klass.Name,
+                    Superclass: klass.Superclass,
+                    Tags: klass.Tags,
                 }
+                output.set(klass.Name, klassData)
             }
 
             return output
         })
     }
 
-    async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
+    public async createCompletionItems(
+        service: ApiClass,
+        operator: string,
+        inheritMembers = true,
+    ): Promise<vscode.CompletionItem[]> {
+        let completionItems: vscode.CompletionItem[] = []
+
+        for (const member of service.Members) {
+            if (member.Security !== "None") {
+                continue
+            }
+
+            if (operator === ":") {
+                if (member.MemberType === "Function") {
+                    const params = []
+
+                    for (const param of member.Parameters) {
+                        let paramText = param.Name
+
+                        if (param.Default !== undefined) {
+                            paramText += ` = ${param.Default}`
+                        }
+
+                        params.push(paramText)
+                    }
+
+                    const completionItem = new vscode.CompletionItem(
+                        `${member.Name}(${params.join(", ")})`,
+                        vscode.CompletionItemKind.Method,
+                    )
+
+                    completionItem.insertText = new vscode.SnippetString(`${member.Name}($0)`)
+
+                    completionItems.push(completionItem)
+                }
+            } else if (operator === ".") {
+                switch (member.MemberType) {
+                    case "Callback":
+                        completionItems.push(new vscode.CompletionItem(
+                            member.Name,
+                            vscode.CompletionItemKind.Constructor,
+                        ))
+                        break
+
+                    case "Event":
+                        completionItems.push(new vscode.CompletionItem(
+                            member.Name,
+                            vscode.CompletionItemKind.Event,
+                        ))
+                        break
+
+                    case "Property":
+                        completionItems.push(new vscode.CompletionItem(
+                            member.Name,
+                            vscode.CompletionItemKind.Field,
+                        ))
+                        break
+                }
+            }
+        }
+
+        if (inheritMembers) {
+            if (service.Superclass) {
+                const klass = (await this.serviceMembers).get(service.Superclass)
+                if (klass) {
+                    const inheritedMembers = await this.createCompletionItems(klass, operator, true)
+                    // TODO: Indicate in the completion that this is inherited
+                    completionItems = completionItems.concat(inheritedMembers)
+                }
+            }
+        }
+
+        return completionItems
+    }
+
+    public async provideCompletionItems(document: vscode.TextDocument, position: vscode.Position) {
         const serviceMatch = document.lineAt(position.line).text.substr(0, position.character).match(/(\w+)([:.]?)\w*$/)
 
         if (serviceMatch !== null) {
             const serviceName = serviceMatch[1]
             const operator = serviceMatch[2]
 
-            const serviceMembers = (await this.serviceMembers).get(serviceName)
+            const service = (await this.serviceMembers).get(serviceName)
 
-            if (serviceMembers !== undefined) {
+            if (service !== undefined && service.Tags && service.Tags.includes("Service")) {
                 const documentText = document.getText()
 
                 if (!documentText.match(new RegExp(`^local ${serviceName}\\s*=\\s*`, "m"))) {
                     const insertText = `local ${serviceName} = game:GetService("${serviceName}")\n`
                     const lines = documentText.split(/\n\r?/)
 
-                    const firstImport = lines.findIndex(line => line.match(IMPORT_PATTERN))
+                    const firstImport = lines.findIndex((line) => line.match(IMPORT_PATTERN))
                     let lineNumber = Math.max(firstImport, 0)
 
                     while (lineNumber < lines.length) {
@@ -78,7 +158,7 @@ export class ServiceCompletionProvider implements vscode.CompletionItemProvider 
                         vscode.TextEdit.insert(
                             new vscode.Position(lineNumber, 0),
                             insertText + (firstImport === -1 ? "\n" : ""),
-                        )
+                        ),
                     ]
 
                     if (operator !== "") {
@@ -92,61 +172,7 @@ export class ServiceCompletionProvider implements vscode.CompletionItemProvider 
                     return [item]
                 }
 
-                const completionItems = []
-
-                for (const member of serviceMembers) {
-                    if (member.Security !== "None") {
-                        continue
-                    }
-
-                    if (operator === ":") {
-                        if (member.MemberType === "Function") {
-                            const params = []
-
-                            for (const param of member.Parameters) {
-                                let paramText = param.Name
-
-                                if (param.Default !== undefined) {
-                                    paramText += ` = ${param.Default}`
-                                }
-
-                                params.push(paramText)
-                            }
-
-                            const completionItem = new vscode.CompletionItem(
-                                `${member.Name}(${params.join(", ")})`,
-                                vscode.CompletionItemKind.Method,
-                            )
-
-                            completionItem.insertText = new vscode.SnippetString(`${member.Name}($0)`)
-
-                            completionItems.push(completionItem)
-                        }
-                    } else if (operator === ".") {
-                        switch (member.MemberType) {
-                            case "Callback":
-                                completionItems.push(new vscode.CompletionItem(
-                                    member.Name,
-                                    vscode.CompletionItemKind.Constructor,
-                                ))
-                                break
-
-                            case "Event":
-                                completionItems.push(new vscode.CompletionItem(
-                                    member.Name,
-                                    vscode.CompletionItemKind.Event,
-                                ))
-                                break
-
-                            case "Property":
-                                completionItems.push(new vscode.CompletionItem(
-                                    member.Name,
-                                    vscode.CompletionItemKind.Field,
-                                ))
-                                break
-                        }
-                    }
-                }
+                const completionItems = await this.createCompletionItems(service, operator, true)
 
                 return completionItems
             }


### PR DESCRIPTION
This PR improves the support for services by:
- ~~making them show up in the general autocomplete when first typing for a new class~~ removed
- inheriting members from superclasses (Closes #31, Closes #18)
- fixing properties not showing up in autocomplete (Fixes #21)
- moving the cursor depending on whether the function takes parameters or not (Closes #16)

It also improves the autocomplete details provided by displaying type information for properties, parameters and return values, and references to the Developer Reference.